### PR TITLE
More correct version comparison; fix missing dirs

### DIFF
--- a/repo-cleaner.py
+++ b/repo-cleaner.py
@@ -1,59 +1,57 @@
 from os.path import isdir
 from os import listdir
-import re
 import shutil
+import semver
+
 import Constants
 
-dry_run = True
+# Change to True to get a log of what will be removed
+dry_run = False
+
 
 def check_and_clean(path):
     files = listdir(path)
-    for file in files:
-        if not isdir('/'.join([path, file])):
-            return
-    last = check_if_versions(files)
-    if last is None:
-        for file in files:
-            check_and_clean('/'.join([path, file]))
-    elif len(files) == 1:
+    only_files = True
+    for index, file in enumerate(files):
+        if isdir('/'.join([path, file])):
+            only_files = False
+        else:
+            files[index] = None
+    if only_files:
+        return
+
+    directories = [d for d in files if d is not None]
+    latest_version = check_if_versions(directories)
+    if latest_version is None:
+        for directory in directories:
+            check_and_clean('/'.join([path, directory]))
+    elif len(directories) == 1:
         return
     else:
-        print('update ' + path.split(Constants.m2_path)[1])
-        for file in files:
-            if file == last:
+        print('Update ' + path.split(Constants.m2_path)[1])
+        for directory in directories:
+            if directory == latest_version:
                 continue
-            print(file + ' (newer version: ' + last + ')')
+            print(directory + ' (Has newer version: ' + latest_version + ')')
             if not dry_run:
-                shutil.rmtree('/'.join([path, file]))
+                shutil.rmtree('/'.join([path, directory]))
 
 
-def check_if_versions(files):
-    if len(files) == 0:
+def check_if_versions(directories):
+    if len(directories) == 0:
         return None
-    last = ''
-    for file in files:
-        if re.match(Constants.version_regex, file):
-            if last == '':
-                last = file
-            if len(last.split('.')) == len(file.split('.')):
-                for (current, new) in zip(last.split('.'), file.split('.')):
-                    if int(new) > int(current):
-                        last = file
-                        break
-                    elif int(new) < int(current):
-                        break
-            else:
-                return None
-        else:
+    latest_version = ''
+    for directory in directories:
+        try:
+            current_version = semver.VersionInfo.parse(directory)
+        except ValueError:
             return None
-    return last
+        if latest_version == '':
+            latest_version = directory
+        if current_version.compare(latest_version) > 0:
+            latest_version = directory
+    return latest_version
 
 
-assert check_if_versions(['1.11.12', '1.13.1']) == '1.13.1'
-assert check_if_versions(['1.11.12', '1.11.3']) == '1.11.12'
-assert check_if_versions(['1.11.12', '2.10.1']) == '2.10.1'
-assert check_if_versions(['1.11.12', '1.13']) is None
-assert check_if_versions(['1.11.12']) == '1.11.12'
-assert check_if_versions([]) is None
-
-check_and_clean(Constants.m2_path)
+if __name__ == '__main__':
+    check_and_clean(Constants.m2_path)


### PR DESCRIPTION
Use more reliable and inclusive version comparison from the PyPi `SemVer` package, thus understanding `major` versions with multiple digits and pre-release/snapshot versions. Fix the incorrect skipping of directories that contain Maven metadata files or spurious OS-specific files like `.DS_Store` on macOS.